### PR TITLE
Dockerfiles refactoring

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -1,10 +1,10 @@
 
 # Setup Debian system
 FROM debian:stretch-slim
-RUN apt-get update && apt-get upgrade -y --no-install-recommends
 
 # Install dependencies
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update -y; \
+    apt-get install -y --no-install-recommends \
     ssh rsync \
     git cvs \
     python-mysqldb mariadb-client mariadb-server \
@@ -14,7 +14,6 @@ RUN apt-get install -y --no-install-recommends \
     vim less wget \
     python-pip python-setuptools \
     libapache2-mod-shib2
-RUN apt-get clean
 
 # Install schedule CGI
 RUN mkdir /var/www/html/htdocs
@@ -69,5 +68,8 @@ RUN cd /etc/shibboleth && chown _shibd sp-*.pem && chmod go= sp-key.pem
 
 COPY config/shibboleth/shibd.sh /var/tmp
 
-ENTRYPOINT service apache2 start && service mysql start && /var/tmp/provision.sh && service shibd start && service shibd status && /var/tmp/show_ip.sh &&/bin/bash
+COPY mysql-shib-httpd-foreground.sh /var/tmp
 
+RUN chmod 744 /var/tmp/mysql-shib-httpd-foreground.sh
+
+CMD ["/var/tmp/mysql-shib-httpd-foreground.sh"]

--- a/portal/mysql-shib-httpd-foreground.sh
+++ b/portal/mysql-shib-httpd-foreground.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+/etc/init.d/mysql start
+
+./var/tmp/provision.sh
+
+/etc/init.d/shibd start
+
+exec apachectl -D FOREGROUND

--- a/portal/run_portal.sh
+++ b/portal/run_portal.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+
 TYPE=dev
 IMAGE_TAG=eiscat-aarc/portal:v6
 CONTAINER_NAME=eiscat-aarc-portal
@@ -13,19 +14,23 @@ RUN_DIR=$PWD
 CONFIG_DIR="$RUN_DIR/config"
 
 
-# Start data portal and server
-#docker start $CONTAINER_NAME || \
-    docker run -it \
-	   --env DATA_DIR=/var/portal \
-	   --net eiscat-aarc.local \
-	   --ip 192.168.111.100 \
-	   --hostname portal.eiscat-aarc.local \
-	   --add-host=idp.eiscat-aarc.local:192.168.111.200 \
-	   --publish 8443:443 \
-	   --publish 37009:37009 \
-	   $IMAGE_TAG
+if [ "$(docker ps -a -q -f name=$CONTAINER_NAME)" != "" ]; then
+    echo "docker container $CONTAINER_NAME exists"
+    echo "starting $CONTAINER_NAME"
+    docker start $CONTAINER_NAME
+else
+    echo "no docker container found"
+    echo "creating container $CONTAINER_NAME from image $IMAGE_TAG"
+    docker run -d \
+        --name $CONTAINER_NAME \
+        --env DATA_DIR=/var/portal \
+        --net eiscat-aarc.local \
+        --ip 192.168.111.100 \
+        --hostname portal.eiscat-aarc.local \
+        --add-host=idp.eiscat-aarc.local:192.168.111.200 \
+        --publish 8443:443 \
+        --publish 37009:37009 \
+        $IMAGE_TAG
+fi
 
-#	   --volume $PWD/workdir:/var/www/html \
-#           --volume $PWD/authdir:/var/www/auth \
-#	   --volume $PWD/archive:/data/archive \
 

--- a/ssp-idp/Dockerfile
+++ b/ssp-idp/Dockerfile
@@ -2,18 +2,24 @@ FROM ubuntu:16.04
 
 EXPOSE 443
 
-RUN apt -y update && apt -y full-upgrade && apt -y autoremove && apt install -y --no-install-recommends sudo dnsutils git software-properties-common
-RUN apt-add-repository -y ppa:ansible/ansible && apt -y update && apt install -y ansible
-RUN apt -y clean
+RUN apt update -y; \
+    apt install -y --no-install-recommends \
+	sudo \
+	dnsutils \
+	git \
+	software-properties-common
 
-RUN git clone https://github.com/surfnet-niels/simplesaml-idp.git /tmp/ansible/simplesaml-idp
+RUN apt-add-repository -y ppa:ansible/ansible; \
+    apt update -y; \ 
+    apt install -y ansible 
+
+RUN git clone https://github.com/OpenConext/OpenConext-DIY  /tmp/ansible/simplesaml-idp
+
 COPY config/ansible/inventory /tmp/ansible/simplesaml-idp/
 COPY config/ansible/idp.yml /tmp/ansible/simplesaml-idp/group_vars/
 
-RUN  ansible-playbook -i /tmp/ansible/simplesaml-idp/inventory /tmp/ansible/simplesaml-idp/simplesaml-idp.yml
+RUN  ansible-playbook -i /tmp/ansible/simplesaml-idp/inventory /tmp/ansible/simplesaml-idp/openconext-diy.yml
 
 COPY config/metadata /var/www/simplesamlphp/metadata
 
-RUN apt-get update && apt-get install -y vim less
-
-ENTRYPOINT service apache2 start && /bin/bash
+CMD ["apachectl","-D", "FOREGROUND"]

--- a/ssp-idp/config/ansible/inventory
+++ b/ssp-idp/config/ansible/inventory
@@ -1,4 +1,4 @@
-target  ansible_host=127.0.0.1
+target  ansible_host=127.0.0.1  ansible_connection=local
 
 [idp]
 target

--- a/ssp-idp/run_ssp-idp.sh
+++ b/ssp-idp/run_ssp-idp.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-set -x
 
 IMAGE_TAG=eiscat-aarc/ssp-idp:v1
 CONTAINER_NAME=eiscat-aarc_ssp-idp

--- a/ssp-idp/run_ssp-idp.sh
+++ b/ssp-idp/run_ssp-idp.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
+set -x
+
 IMAGE_TAG=eiscat-aarc/ssp-idp:v1
 CONTAINER_NAME=eiscat-aarc_ssp-idp
 
@@ -9,23 +11,33 @@ if [ ! "$(docker network ls | grep eiscat-aarc.local)" ]; then
 else
   echo "eiscat-aarc.local network exists."
 fi
+
 # Build the docker image if needed
 if [[ "$(docker images -q $IMAGE_TAG 2> /dev/null)" == "" ]]; then
-  echo "Creating $IMAGE_TAG docker container ..."
+  echo "Creating $IMAGE_TAG docker image ..."
   docker build -t $IMAGE_TAG .
 else
-  echo "$IMAGE_TAG docker container exists..."
+  echo "$IMAGE_TAG docker image exists..."
 fi
 
-# Start SSP IDP
-docker start -i $CONTAINER_NAME || docker run -it \
-    --name $CONTAINER_NAME \
-    --net eiscat-aarc.local \
-    --ip 192.168.111.200 \
-    --add-host=portal.eiscat-aarc.local:192.168.111.100 \
-    --add-host=data.eiscat-aarc.local:192.168.111.101 \
-    --add-host=idp.eiscat-aarc.local:192.168.111.200 \
-    --hostname idp.eiscat-aarc.local \
-    --publish 9080:80 \
-    --publish 9443:443 \
-    $IMAGE_TAG
+
+if [ "$(docker ps -a -q -f name=$CONTAINER_NAME)" != "" ]; then
+    echo "docker container $CONTAINER_NAME exists"
+    echo "starting $CONTAINER_NAME"
+    docker start $CONTAINER_NAME
+else
+    echo "no docker container found"
+    echo "creating container $CONTAINER_NAME from image $IMAGE_TAG"
+    docker run -d \
+        --name $CONTAINER_NAME \
+        --net eiscat-aarc.local \
+        --ip 192.168.111.200 \
+        --add-host=portal.eiscat-aarc.local:192.168.111.100 \
+        --add-host=data.eiscat-aarc.local:192.168.111.101 \
+        --add-host=idp.eiscat-aarc.local:192.168.111.200 \
+        --hostname idp.eiscat-aarc.local \
+        --publish 9080:80 \
+        --publish 9443:443 \
+        $IMAGE_TAG
+fi
+


### PR DESCRIPTION
Dockerfile changes:
* replaced `service start ..` with directly calling main process, such as httpd. In case of many processes using a start script
* no longer upgrade global packages: base image maintainers have the responsability of keeping the base image uptodate. To upgrade delete base image from cache, such as debian an ubuntu one, or build with `--no-cache` argument
* CMD instead of ENTRYPOINT: we do not need to pass arguments to the main foreground process

Other minor fixed, improvements

